### PR TITLE
Use HTMLMediaElement srcObject for MediaStreams if available

### DIFF
--- a/src/imagecapture.js
+++ b/src/imagecapture.js
@@ -43,7 +43,11 @@ if (typeof ImageCapture === 'undefined') {
       this.videoElementPlaying = new Promise(resolve => {
         this.videoElement.addEventListener('playing', resolve);
       });
-      this.videoElement.srcObject = this._previewStream;
+      if (this.videoElement.srcObject) {
+          this.videoElement.srcObject = this._previewStream; // Safari 11 doesn't allow use of createObjectURL for MediaStream
+      } else {
+          this.videoElement.src = URL.createObjectURL(this._previewStream);
+      }
       this.videoElement.muted = true;
       this.videoElement.setAttribute('playsinline', ''); // Required by Safari on iOS 11. See https://webkit.org/blog/6784
       this.videoElement.play();

--- a/src/imagecapture.js
+++ b/src/imagecapture.js
@@ -43,7 +43,7 @@ if (typeof ImageCapture === 'undefined') {
       this.videoElementPlaying = new Promise(resolve => {
         this.videoElement.addEventListener('playing', resolve);
       });
-      if (this.videoElement.srcObject) {
+      if (HTMLMediaElement) {
           this.videoElement.srcObject = this._previewStream; // Safari 11 doesn't allow use of createObjectURL for MediaStream
       } else {
           this.videoElement.src = URL.createObjectURL(this._previewStream);

--- a/src/imagecapture.js
+++ b/src/imagecapture.js
@@ -43,7 +43,7 @@ if (typeof ImageCapture === 'undefined') {
       this.videoElementPlaying = new Promise(resolve => {
         this.videoElement.addEventListener('playing', resolve);
       });
-      this.videoElement.src = URL.createObjectURL(this._previewStream);
+      this.videoElement.srcObject = this._previewStream;
       this.videoElement.muted = true;
       this.videoElement.setAttribute('playsinline', ''); // Required by Safari on iOS 11. See https://webkit.org/blog/6784
       this.videoElement.play();


### PR DESCRIPTION
When HTMLMediaElement interface is available use srcObject video property instead of using URL.createObjectURL to assign MediaStream.

On Safari 11 it throws error when using URL.createObjectURL on MediaStream object. On Firefox it shows only warning.

More details (first note):
https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL