### PR TITLE
fix: use image/jpeg as the target format

### DIFF
--- a/src/imagecapture.js
+++ b/src/imagecapture.js
@@ -123,7 +123,7 @@ if (typeof ImageCapture === 'undefined') {
             self.canvasElement.width = self.videoElement.videoWidth;
             self.canvasElement.height = self.videoElement.videoHeight;
             self.canvas2dContext.drawImage(self.videoElement, 0, 0);
-            self.canvasElement.toBlob(resolve);
+            self.canvasElement.toBlob(resolve, "image/jpeg");
           } catch (error) {
             reject(new DOMException('UnknownError'));
           }


### PR DESCRIPTION
when using the Chrome's native ImageCapture it outputs a JPEG. Default [`HTMLCanvasElement.toBlob()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob) outputs a `png` unless otherwise specified.
This change aligns those two implementations.